### PR TITLE
docs: fix build status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MH-Z14A Python Library
 
-[![CI](https://github.com/oaslananka/mhz14a/actions/workflows/ci.yml/badge.svg)](https://github.com/oaslananka/mhz14a/actions/workflows/ci.yml)
+[![CI](https://github.com/oaslananka/mhz14a-lib/actions/workflows/ci.yml/badge.svg)](https://github.com/oaslananka/mhz14a-lib/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/mhz14a.svg)](https://pypi.org/project/mhz14a/)
 [![Python versions](https://img.shields.io/pypi/pyversions/mhz14a.svg)](https://pypi.org/project/mhz14a/)
 


### PR DESCRIPTION
Fixes the build status badge URL in README.md to point to the correct repository.

## Changes
- Fixed repository name in CI badge URL from `mhz14a` to `mhz14a-lib`
- Badge now correctly displays the actual CI status for this repository

## Before
```
[![CI](https://github.com/oaslananka/mhz14a/actions/workflows/ci.yml/badge.svg)]
```

## After
```
[![CI](https://github.com/oaslananka/mhz14a-lib/actions/workflows/ci.yml/badge.svg)]
```

Closes #1